### PR TITLE
修复cl-text设置超大号字体时导致的多行重叠和web端显示不全的问题

### DIFF
--- a/uni_modules/cool-ui/components/cl-text/cl-text.uvue
+++ b/uni_modules/cool-ui/components/cl-text/cl-text.uvue
@@ -209,9 +209,17 @@ const textStyle = computed(() => {
 	}
 
 	// 行高
-	const lineHeight = getLineHeight();
-	if (lineHeight != null) {
-		style["lineHeight"] = lineHeight;
+	// 判断是否多行文本
+	const isMultiLine = props.preWrap || !props.ellipsis || props.lines > 1;
+	if (isMultiLine) {
+		// 多行文本，行高交给浏览器/平台自动计算
+		style["lineHeight"] = "normal";
+	} else {
+		// 单行文本，使用原来的行高逻辑
+		const lineHeight = getLineHeight();
+		if (lineHeight != null) {
+			style["lineHeight"] = lineHeight;
+		}
 	}
 
 	return style;


### PR DESCRIPTION
修复此问题

<img width="416" height="382" alt="截屏2025-11-05 23 25 41" src="https://github.com/user-attachments/assets/abe9ccfb-f796-4f1a-8321-470dd12d45bc" />

![IMG_7300](https://github.com/user-attachments/assets/dd5f6848-35c3-4915-8c11-ba37f530cae3)
